### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-test if auto reveiw tirgger works on this PR
+test if auto review trigger works on this PR


### PR DESCRIPTION
## Summary
- Fix two typos in README.md: "reveiw" → "review" and "tirgger" → "trigger"

## Test plan
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)